### PR TITLE
Implemented GET request handler for getting all patterns

### DIFF
--- a/db/models/patterns.js
+++ b/db/models/patterns.js
@@ -29,4 +29,23 @@ module.exports = {
       });
     });
   },
+
+  getAllPatterns(count, offset, callback) {
+    const query = `SELECT * FROM patterns
+                   WHERE reported=false
+                   ORDER BY created_at DESC
+                   LIMIT ${count} OFFSET ${offset};`;
+    db.connect((err, client, release) => {
+      if (err) {
+        console.error('Error getting patterns', err.stack);
+      }
+      client.query(query, (error, result) => {
+        release();
+        if (error) {
+          callback(err.stack);
+        }
+        callback(null, result);
+      });
+    });
+  },
 };

--- a/server/controllers/patterns.js
+++ b/server/controllers/patterns.js
@@ -9,4 +9,22 @@ module.exports = {
       res.status(200).send(results.rows[0]);
     });
   },
+
+  getAllPatterns(req, res) {
+    let count = 50;
+    let page = 0;
+    if (req.query.count !== undefined) {
+      count = req.query.count;
+    }
+    if (req.query.page !== undefined) {
+      page = req.query.page;
+    }
+    const offset = count * page;
+    patternsModels.getAllPatterns(count, offset, (err, results) => {
+      if (err) {
+        res.status(404).send('Fail to get patterns', err);
+      }
+      res.status(200).send(results.rows);
+    });
+  },
 };

--- a/server/routes.js
+++ b/server/routes.js
@@ -7,6 +7,7 @@ const userPurchased = require('./controllers/user_purchased');
 /* "Pattern" ========================================= */
 // (load patterns)
 router.get('/patterns/:pattern_id', patterns.getOnePattern);
+router.get('/patterns/', patterns.getAllPatterns);
 // (add pattern)
 router.post('/patterns');
 // (report pattern)


### PR DESCRIPTION
- new endpoint for getting all patterns `router.get('/patterns/', patterns.getAllPatterns);`
- Entry count and page should be in the req.query when being sent to the server. 
- If no specify entry count and page, default count=50, page=0 
- Output is ordered by created_at DESC